### PR TITLE
Add prerequisites to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This repository contains two demos that can help understanding how to use Membrane Framework.
 
+## Prerequisites
+
+1. Make sure you have Elixir installed on your machine. See: https://elixir-lang.org/install.html
+1. Fetch the required dependencies by running `mix deps.get`
+
 ## First Pipeline Demo
 
 ### How to run


### PR DESCRIPTION
## Description
Adds an additional prerequisites steps to README.
Running the example immediately will fails with:
```elixir
Unchecked dependencies for environment dev:
* membrane_core (Hex package)
  the dependency is not available, run "mix deps.get"
* membrane_element_portaudio (Hex package)
  the dependency is not available, run "mix deps.get"
* membrane_loggers (Hex package)
  the dependency is not available, run "mix deps.get"
* membrane_element_mad (Hex package)
  the dependency is not available, run "mix deps.get"
* membrane_element_file (Hex package)
  the dependency is not available, run "mix deps.get"
* membrane_element_ffmpeg_swresample (Hex package)
  the dependency is not available, run "mix deps.get"
** (Mix) Can't continue due to errors on dependencies
```