### PR TITLE
Updated RTP prereq with ffmpeg version number

### DIFF
--- a/rtp/README.md
+++ b/rtp/README.md
@@ -19,7 +19,7 @@ You have to have installed the following packages on your system:
 
 * SDL 2
 * gstreamer
-* ffmpeg
+* ffmpeg 4.x
 * PortAudio
 
 ## Run the demo


### PR DESCRIPTION
I had issues getting the RTP demo video to work and it turned out that ffmpeg 4.x was required. Updated the README to specify the ffmpeg version number in the prereq section.